### PR TITLE
Fixed flipped player sprite issue (#160)

### DIFF
--- a/src/entity/system/System.cpp
+++ b/src/entity/system/System.cpp
@@ -64,7 +64,7 @@ namespace Framework
 		
 		if (c_pos && c_sprite)
 		{
-			c_sprite->sprite.setScale(static_cast<float>(c_sprite->flipX ? 1 : -1), static_cast<float>(c_sprite->flipY ? 1 : -1));
+			c_sprite->sprite.setScale(static_cast<float>(c_sprite->flipX ? 1 : -1), static_cast<float>(c_sprite->flipY ? -1 : 1));
 			c_sprite->sprite.setOrigin(static_cast<float>(c_sprite->sprite.getTextureRect().width / 2), static_cast<float>(c_sprite->sprite.getTextureRect().height));
 			Level::LevelRenderer::renderEntitySprite(c_pos->position.x, c_pos->position.y, c_sprite->sprite);
 		}


### PR DESCRIPTION
The issue with the flipped player sprite was an incorrectly ordered ternary operator assigning the incorrect value to the bool flipY.

This should fix #160, however I only compile on Windows 10 so feedback from someone on Linux would be great.