### PR TITLE
FileReader now ignores BOM when reading UTF-8 (with signature) files, Fixed laggy zombie AI

### DIFF
--- a/src/entity/system/System.cpp
+++ b/src/entity/system/System.cpp
@@ -30,14 +30,14 @@ namespace Framework
 			bool colliding = c_col ? Physics::tileCollision(Vec2i(dest), c_col->aabb) : false;
 			if (!colliding)
 			{
-				c_pos->position.x = round(dest.x);
-				c_pos->position.y = round(dest.y);
+				c_pos->position.x = dest.x;
+				c_pos->position.y = dest.y;
 			}
 		}
 		else
 		{
-			c_pos->position.x = round(dest.x);
-			c_pos->position.y = round(dest.y);
+			c_pos->position.x = dest.x;
+			c_pos->position.y = dest.y;
 		}
 	}
 
@@ -142,7 +142,7 @@ namespace Framework
 				// Check if player is in distance of this entity and set it as target if it is,
 				// otherwise set target to non-moving, necessary for the right animation to play
 
-				Entity* player = State::SPlaying::instance->m_level.getEntity(State::SPlaying::instance->m_level.player_id);
+				Entity* player = State::SPlaying::instance->m_level.player;
 				PositionComponent* c_pos_player = player->getComponent<PositionComponent>();
 
 				// Tile flooding for every entity is not ideal as it really kills the fps

--- a/src/level/Level.h
+++ b/src/level/Level.h
@@ -24,7 +24,7 @@ namespace Level
             void addEntity(std::unique_ptr<Framework::Entity> entity);
             Framework::Entity* getEntity(const uint64& id);
 
-			Framework::Entity* getPlayer() { return getEntity(player_id); }
+			Framework::Entity* getPlayer() { return player; }
 
 			void setTile(unsigned int x, unsigned int y, Tile::Tile& tile);
             Tile::Tile* getTile(unsigned int x, unsigned int y);
@@ -44,6 +44,6 @@ namespace Level
 			std::unique_ptr<Framework::System> m_renderSystem;
 			std::vector<std::unique_ptr<Framework::System>> m_updateSystems;
 		public:
-			uint64 player_id;
+			Framework::Entity* player;
 	};
 }

--- a/src/states/StatePlaying.cpp
+++ b/src/states/StatePlaying.cpp
@@ -48,8 +48,8 @@ namespace State
 
 		std::unique_ptr<Framework::Entity> player = Framework::EntityFactory::createEntity("Player");
 
-		m_level.player_id = player->getID();
-		std::cout << "Player ID: " << m_level.player_id << std::endl;
+		m_level.player = player.get();
+		std::cout << "Player ID: " << m_level.player->getID() << std::endl;
 
 		m_level.addEntity(std::move(player));
 
@@ -69,7 +69,7 @@ namespace State
                     m_level.setTile(x, y, *Level::Tile::Tile::stoneWall);
             }
 
-		m_level.getEntity(m_level.player_id)->getComponent<Framework::PositionComponent>()->position = Vec2(static_cast<float>(data.playerPosition.x * 32), static_cast<float>(data.playerPosition.y * 32));
+		m_level.getPlayer()->getComponent<Framework::PositionComponent>()->position = Vec2(static_cast<float>(data.playerPosition.x * 32), static_cast<float>(data.playerPosition.y * 32));
 
 		std::unique_ptr<Framework::Entity> zombie = Framework::EntityFactory::createEntity("enemy/Zombie");
 		zombie->getComponent<Framework::PositionComponent>()->position = Vec2(static_cast<float>(data.playerPosition.x * 32 + 210), static_cast<float>(data.playerPosition.y * 32 + 210));
@@ -104,7 +104,7 @@ namespace State
 		int offsetX = static_cast<int>((mouseX - halfWidth) * 0.1f);
 		int offsetY = static_cast<int>((mouseY - halfHeight) * 0.1f);
 
-		Framework::PositionComponent* c_pos = m_level.getEntity(m_level.player_id)->getComponent<Framework::PositionComponent>();
+		Framework::PositionComponent* c_pos = m_level.getPlayer()->getComponent<Framework::PositionComponent>();
 		m_camera.setCenter(c_pos->position.x + offsetX, c_pos->position.y+0.01f +offsetY);
 
         m_testFloat = ts.asSeconds();

--- a/src/util/FileUtil.cpp
+++ b/src/util/FileUtil.cpp
@@ -1,18 +1,44 @@
-#include "FileUtil.h"
+﻿#include "FileUtil.h"
 
-#include <iostream>
+// Code is referenced from:
+// https://vicidi.wordpress.com/2015/03/09/reading-utf-file-with-bom-to-utf-8-encoded-stdstring-in-c11-on-windows/
+
 #include <fstream>
 #include <sstream>
 
+#define ENCODING_ASCII      0
+#define ENCODING_UTF8       1
+
 std::string getFileContents(const std::string& filePath)
 {
-    std::ifstream inFile(filePath);
-    if (!inFile.is_open())
-    {
-        std::cerr << "Unable to read " << filePath << "\n";
-    }
+	std::string result;
+	std::ifstream ifs(filePath.c_str(), std::ios::binary);
+	std::stringstream ss;
+	int encoding = ENCODING_ASCII;
 
-    std::stringstream stream;
-    stream << inFile.rdbuf();
-    return stream.str();
+	if (!ifs.is_open()) 
+	{
+		result.clear(); // Unable to read file
+		return result;
+	}
+	else if (ifs.eof())
+		result.clear();
+	else 
+	{
+		int ch1 = ifs.get();
+		int ch2 = ifs.get();
+		
+		int ch3 = ifs.get();
+		if (ch1 == 0xef && ch2 == 0xbb && ch3 == 0xbf) 
+			encoding = ENCODING_UTF8; // The file contains UTF-8 BOM
+		else 
+		{
+			encoding = ENCODING_ASCII; // The file does not have BOM
+			ifs.seekg(0);
+		}
+	}
+	ss << ifs.rdbuf() << '\0';
+	result = ss.str();
+
+	return result;
 }


### PR DESCRIPTION
FileReader now ignores BOM when reading UTF-8 (with signature) files (default encoding for Visual Studio) and cause crashes with JSON parsing (unexpected symbols)
Access player from level was only possible via ID and a for loop which was a very stupid idea and I don't what was I thinking. When you got closer to Zombie UPs got -20 and caused an Illusion that player was again moving faster certain directions...