### PR TITLE
Changed tuple initializers to explicit

### DIFF
--- a/src/entity/component/AIComponent.cpp
+++ b/src/entity/component/AIComponent.cpp
@@ -26,7 +26,7 @@ namespace Entity
 
 			if (c_target_physics)
 			{
-				std::vector<AStar::Location> path = AStar::constructPath({ (int32)c_physics->pos.x >> 5, (int32)c_physics->pos.y >> 5 }, { (int32)c_target_physics->pos.x >> 5, (int32)c_target_physics->pos.y >> 5 });
+				std::vector<AStar::Location> path = AStar::constructPath(std::make_tuple((int32)c_physics->pos.x >> 5, (int32)c_physics->pos.y >> 5), std::make_tuple((int32)c_target_physics->pos.x >> 5, (int32)c_target_physics->pos.y >> 5 ));
 
 				int xa = 0, ya = 0;
 

--- a/src/level/Level.cpp
+++ b/src/level/Level.cpp
@@ -23,9 +23,9 @@ namespace Level
 			{
 				auto n = data.tiles[x][y];
 				if (n == 1)
-					addList.push_back({ x, y, (byte)TileID::Dungeon_BrickFloor, 0 });
+					addList.push_back(std::make_tuple(x, y, (byte)TileID::Dungeon_BrickFloor, 0 ));
 				else
-					addList.push_back({ x, y, (byte)TileID::Dungeon_BrickWall, 0 });
+					addList.push_back(std::make_tuple( x, y, (byte)TileID::Dungeon_BrickWall, 0 ));
 			}
 
 		m_tiles.addTiles(0, addList);

--- a/src/level/tile/TileMap.cpp
+++ b/src/level/tile/TileMap.cpp
@@ -24,7 +24,7 @@ namespace Level
 
 	void TileMap::addTile(uint x, uint y, uint layer, byte id, byte metadata) 
 	{
-		addTiles(layer, { {x, y, id, metadata} });
+		addTiles(layer, { std::make_tuple(x, y, id, metadata) });
 		generateVertexArray(layer);
 	}
 


### PR DESCRIPTION
Gcc didn't want to use initializer lists - {10, 3} for tuples, so I changed it to explicit ones a.k.a. std::tuple<int, int>(10, 3)