### PR TITLE
Hitboxes for UI elements are now good when rescaling the window

### DIFF
--- a/src/ui/UI.cpp
+++ b/src/ui/UI.cpp
@@ -18,7 +18,7 @@ namespace UI
 		for (UIComponent* comp : m_components)
 		{
 			auto transform = comp->getTransform();
-			auto mousePos = input.mousePosition(*m_owningWindow);
+			auto mousePos = Vec2i(m_owningWindow->mapPixelToCoords(input.mousePosition(*m_owningWindow), m_uiView));
 			if (transform.contains(mousePos))
 			{
 				auto relativeMP = mousePos - sf::Vector2i(transform.left, transform.top);


### PR DESCRIPTION
Fixes #154, UI elements' hitbox `position` and `dimension` when resizing the game window

As per #154 whenever we changed the window resolution, the hitboxes were offset from where they were supposed to be. That has been fixed.

Now uses built-in SFML method to calculate mouse position in UI view. After some tests I concluded that now it is working like it's supposed to be.
